### PR TITLE
don't hide EN_ACK_PAY requirements; adjusted examples & docs 

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -633,8 +633,8 @@ bool RF24::begin(void)
     // Set 1500uS (minimum for 32B payload in ESB@250KBPS) timeouts, to make testing a little easier
     // WARNING: If this is ever lowered, either 250KBS mode with AA is broken or maximum packet
     // sizes must never be used. See documentation for a more complete explanation.
-    setRetries(5, 15);   
- 
+    setRetries(5, 15);
+
     // Then set the data rate to the slowest (and most reliable) speed supported by all
     // hardware.
     setDataRate(RF24_1MBPS);
@@ -662,7 +662,7 @@ bool RF24::begin(void)
     // Clear CONFIG register, Enable PTX, Power Up & 16-bit CRC
     // Do not write CE high so radio will remain in standby I mode
     // PTX should use only 22uA of power
-    write_register(NRF_CONFIG, (_BV(EN_CRC) | _BV(CRCO)) );    
+    write_register(NRF_CONFIG, (_BV(EN_CRC) | _BV(CRCO)) );
     config_reg = read_register(NRF_CONFIG);
 
     powerUp();
@@ -1027,7 +1027,7 @@ bool RF24::txStandBy(uint32_t timeout, bool startTx)
 /****************************************************************************/
 
 void RF24::maskIRQ(bool tx, bool fail, bool rx)
-{    
+{
     /* clear the interrupt flags */
     config_reg &= ~(1 << MASK_MAX_RT | 1 << MASK_TX_DS | 1 << MASK_RX_DR);
     /* set the specified interrupt flags */
@@ -1280,7 +1280,7 @@ void RF24::disableDynamicPayloads(void)
 void RF24::enableAckPayload(void)
 {
     //
-    // enable ack payload and dynamic payload features
+    // enable ack payload (and dynamic payload feature for pipe 0)
     //
 
     //toggle_features();
@@ -1288,10 +1288,8 @@ void RF24::enableAckPayload(void)
 
     IF_SERIAL_DEBUG(printf("FEATURE=%i\r\n", read_register(FEATURE)));
 
-    //
-    // Enable dynamic payload on pipes 0 & 1
-    //
-    write_register(DYNPD, read_register(DYNPD) | _BV(DPL_P1) | _BV(DPL_P0));
+    // Enable dynamic payload on pipe 0
+    write_register(DYNPD, read_register(DYNPD) | _BV(DPL_P0));
     dynamic_payloads_enabled = true;
     ack_payloads_enabled = true;
 }
@@ -1524,7 +1522,7 @@ rf24_crclength_e RF24::getCRCLength(void)
     rf24_crclength_e result = RF24_CRC_DISABLED;
     uint8_t AA = read_register(EN_AA);
     config_reg = read_register(NRF_CONFIG);
-    
+
     if (config_reg & _BV(EN_CRC) || AA) {
         if (config_reg & _BV(CRCO)) {
             result = RF24_CRC_16;
@@ -1563,7 +1561,7 @@ void RF24::startConstCarrier(rf24_pa_dbm_e level, uint8_t channel )
 
 /****************************************************************************/
 void RF24::stopConstCarrier()
-{   
+{
     write_register(RF_SETUP, (read_register(RF_SETUP)) & ~_BV(CONT_WAVE));
     write_register(RF_SETUP, (read_register(RF_SETUP)) & ~_BV(PLL_LOCK));
     ce(LOW);

--- a/RF24.h
+++ b/RF24.h
@@ -809,13 +809,23 @@ public:
     uint8_t getDynamicPayloadSize(void);
 
     /**
-     * Enable custom payloads on the acknowledge packets
+     * Enable custom payloads in the acknowledge packets
      *
-     * Ack payloads are a handy way to return data back to senders without
+     * ACK payloads are a handy way to return data back to senders without
      * manually changing the radio modes on both units.
      *
-     * @note Ack payloads are dynamic payloads. This only works on pipes 0&1 by default. Call
-     * enableDynamicPayloads() to enable on all pipes.
+     * @remarks The ACK payload feature requires the auto-ack feature to be
+     * enabled for any pipe using ACK payloads. This function does not
+     * automatically enable the auto-ack feature on pipe 0 since the auto-ack
+     * feature is enabled for all pipes by default.
+     *
+     * @see setAutoAck()
+     *
+     * @note ACK payloads are dynamic payloads. This function automatically
+     * enables dynamic payloads on pipe 0 by default. Call
+     * enableDynamicPayloads() to enable on all pipes (especially for RX nodes
+     * that use pipes other than pipe 0 to receive transmissions expecting
+     * responses with ACK payloads).
      */
     void enableAckPayload(void);
 
@@ -889,7 +899,7 @@ public:
      * The power levels correspond to the following output levels respectively:
      * NRF24L01: -18dBm, -12dBm,-6dBM, and 0dBm, lnaEnable affects modules with LNA
      *
-     * SI24R1: -6dBm, 0dBm, 3dBm and 7dBm with lnaEnable = 1 
+     * SI24R1: -6dBm, 0dBm, 3dBm and 7dBm with lnaEnable = 1
      *        -12dBm,-4dBm, 1dBm and 4dBm with lnaEnable = 0
      *
      * @param level Desired PA level.
@@ -1001,14 +1011,14 @@ public:
 
     /**
      * Transmission of constant carrier wave with defined frequency and output power
-     * 
+     *
      * @param level Output power to use
      * @param channel The channel to use
-     */    
+     */
     void startConstCarrier(rf24_pa_dbm_e level, uint8_t channel);
 
     /**
-     * Stop transmission of constant wave and reset PLL and CONT registers  
+     * Stop transmission of constant wave and reset PLL and CONT registers
      */
     void stopConstCarrier(void);
 
@@ -1460,7 +1470,7 @@ private:
  * - Minor fixes & changes
  *
  *
- * 
+ *
  * @section Useful Useful References
  *
  *
@@ -1476,8 +1486,8 @@ private:
  * @li <a href="http://tmrh20.github.io/RF24Mesh"> <b>RF24Mesh:</b> Dynamic Mesh Layer for RF24Network</a>
  * @li <a href="http://tmrh20.github.io/RF24Ethernet"> <b>RF24Ethernet:</b> TCP/IP Radio Mesh Networking (shares Arduino Ethernet API)</a>
  * @li <a href="http://tmrh20.github.io/RF24Audio"> <b>RF24Audio:</b> Realtime Wireless Audio streaming</a>
- * @li <a href="http://tmrh20.blogspot.com/2014/03/high-speed-data-transfers-and-wireless.html"><b>My Blog:</b> RF24 Optimization Overview</a> 
- * @li <a href="http://tmrh20.blogspot.com/2016/08/raspberry-pilinux-with-nrf24l01.html"><b>My Blog:</b> RPi/Linux w/RF24Gateway</a> 
+ * @li <a href="http://tmrh20.blogspot.com/2014/03/high-speed-data-transfers-and-wireless.html"><b>My Blog:</b> RF24 Optimization Overview</a>
+ * @li <a href="http://tmrh20.blogspot.com/2016/08/raspberry-pilinux-with-nrf24l01.html"><b>My Blog:</b> RPi/Linux w/RF24Gateway</a>
  * @li <a href="http://tmrh20.github.io/">All TMRh20 Documentation Main Page</a>
  *
  * **More Information**
@@ -1517,27 +1527,27 @@ private:
  *
  * @li [0] https://learn.sparkfun.com/tutorials/tiny-avr-programmer-hookup-guide/attiny85-use-hints
  * @li [1] http://highlowtech.org/?p=1695
- * @li [2] http://littlewire.cc/   
+ * @li [2] http://littlewire.cc/
  * <br><br><br>
  *
  *
  *
  *
  * @page Arduino Arduino
- * 
+ *
  * RF24 is fully compatible with Arduino boards <br>
  * See <b> http://www.arduino.cc/en/Reference/Board </b> and <b> http://arduino.cc/en/Reference/SPI </b> for more information
- * 
+ *
  * RF24 makes use of the standard hardware SPI pins (MISO,MOSI,SCK) and requires two additional pins, to control
  * the chip-select and chip-enable functions.<br>
- * These pins must be chosen and designated by the user, in RF24 radio(ce_pin,cs_pin); and can use any 
+ * These pins must be chosen and designated by the user, in RF24 radio(ce_pin,cs_pin); and can use any
  * available pins.
- * 
+ *
  * <br>
  * @section Alternate_SPI Alternate SPI Support
  *
  * RF24 supports alternate SPI methods, in case the standard hardware SPI pins are otherwise unavailable.
- * 
+ *
  * <br>
  * **Software Driven SPI**
  *
@@ -1545,8 +1555,8 @@ private:
  *
  * Setup:<br>
  * 1. Install the digitalIO library<br>
- * 2. Open RF24_config.h in a text editor. 
-      Uncomment the line 
+ * 2. Open RF24_config.h in a text editor.
+      Uncomment the line
       @code
       #define SOFTSPI
       @endcode
@@ -1571,11 +1581,11 @@ private:
  * <br>
  * **Alternate Hardware (UART) Driven  SPI**
  *
- * The Serial Port (UART) on Arduino can also function in SPI mode, and can double-buffer data, while the 
+ * The Serial Port (UART) on Arduino can also function in SPI mode, and can double-buffer data, while the
  * default SPI hardware cannot.
  *
  * The SPI_UART library is available at https://github.com/TMRh20/Sketches/tree/master/SPI_UART
- * 
+ *
  * Enabling:
  * 1. Install the SPI_UART library
  * 2. Edit RF24_config.h and uncomment `#define SPI_UART`
@@ -1593,12 +1603,12 @@ private:
  *
  * @note SPI_UART on Mega boards requires soldering to an unused pin on the chip. <br>See
  * https://github.com/TMRh20/RF24/issues/24 for more information on SPI_UART.
- * 
+ *
  * @page ATTiny ATTiny
  *
  * ATTiny support is built into the library, so users are not required to include SPI.h in their sketches<br>
  * See the included rf24ping85 example for pin info and usage
- * 
+ *
  * Some versions of Arduino IDE may require a patch to allow use of the full program space on ATTiny<br>
  * See https://github.com/TCWORLD/ATTinyCore/tree/master/PCREL%20Patch%20for%20GCC for ATTiny patch
  *
@@ -1606,7 +1616,7 @@ private:
  *
  * @section Hardware Hardware Configuration
  * By tong67 ( https://github.com/tong67 )
- * 
+ *
  *    **ATtiny25/45/85 Pin map with CE_PIN 3 and CSN_PIN 4**
  * @code
  *                                 +-\/-+
@@ -1614,7 +1624,7 @@ private:
  *    nRF24L01  CE, pin3 --- PB3  2|    |7  PB2 --- nRF24L01  SCK, pin5
  *    nRF24L01 CSN, pin4 --- PB4  3|    |6  PB1 --- nRF24L01 MOSI, pin6
  *    nRF24L01 GND, pin1 --- GND  4|    |5  PB0 --- nRF24L01 MISO, pin7
- *                                 +----+ 
+ *                                 +----+
  * @endcode
  *
  * <br>
@@ -1625,22 +1635,22 @@ private:
  *    This configuration is enabled when CE_PIN and CSN_PIN are equal, e.g. both 3                      <br>
  *    Because CE is always high the power consumption is higher than for 5 pins solution                <br>
  * @code
- *                                                                                           ^^         
- *                                 +-\/-+           nRF24L01   CE, pin3 ------|              //         
- *                           PB5  1|o   |8  Vcc --- nRF24L01  VCC, pin2 ------x----------x--|<|-- 5V    
- *                   NC      PB3  2|    |7  PB2 --- nRF24L01  SCK, pin5 --|<|---x-[22k]--|  LED         
- *                   NC      PB4  3|    |6  PB1 --- nRF24L01 MOSI, pin6  1n4148 |                       
- *    nRF24L01 GND, pin1 -x- GND  4|    |5  PB0 --- nRF24L01 MISO, pin7         |                       
- *                        |        +----+                                       |                       
- *                        |-----------------------------------------------||----x-- nRF24L01 CSN, pin4  
- *                                                                      10nF                            
+ *                                                                                           ^^
+ *                                 +-\/-+           nRF24L01   CE, pin3 ------|              //
+ *                           PB5  1|o   |8  Vcc --- nRF24L01  VCC, pin2 ------x----------x--|<|-- 5V
+ *                   NC      PB3  2|    |7  PB2 --- nRF24L01  SCK, pin5 --|<|---x-[22k]--|  LED
+ *                   NC      PB4  3|    |6  PB1 --- nRF24L01 MOSI, pin6  1n4148 |
+ *    nRF24L01 GND, pin1 -x- GND  4|    |5  PB0 --- nRF24L01 MISO, pin7         |
+ *                        |        +----+                                       |
+ *                        |-----------------------------------------------||----x-- nRF24L01 CSN, pin4
+ *                                                                      10nF
  * @endcode
  *
  * <br>
  *    **ATtiny24/44/84 Pin map with CE_PIN 8 and CSN_PIN 7** <br>
  *	Schematic provided and successfully tested by Carmine Pastore (https://github.com/Carminepz) <br>
  * @code
- *                                  +-\/-+                                                              
+ *                                  +-\/-+
  *    nRF24L01  VCC, pin2 --- VCC  1|o   |14 GND --- nRF24L01  GND, pin1
  *                            PB0  2|    |13 AREF
  *                            PB1  3|    |12 PA1
@@ -1649,12 +1659,12 @@ private:
  *                            PA7  6|    |9  PA4 --- nRF24L01  SCK, pin5
  *    nRF24L01 MISO, pin7 --- PA6  7|    |8  PA5 --- nRF24L01 MOSI, pin6
  *                                  +----+
- *	@endcode					 
- *	
+ *	@endcode
+ *
  * <br>
  *    **ATtiny2313/4313 Pin map with CE_PIN 12 and CSN_PIN 13** <br>
  * @code
- *                                  +-\/-+                                                              
+ *                                  +-\/-+
  *                            PA2  1|o   |20 VCC --- nRF24L01  VCC, pin2
  *                            PD0  2|    |19 PB7 --- nRF24L01  SCK, pin5
  *                            PD1  3|    |18 PB6 --- nRF24L01 MOSI, pin6
@@ -1666,13 +1676,13 @@ private:
  *                            PD5  9|    |12 PB0
  *    nRF24L01  GND, pin1 --- GND 10|    |11 PD6
  *                                  +----+
- *	@endcode					 
+ *	@endcode
  *
  * <br><br><br>
  *
  *
- * 
- * 
+ *
+ *
  *
  *
  * @page Linux Linux Installation
@@ -1682,10 +1692,10 @@ private:
  *  @note The SPIDEV option should work with most Linux systems supporting spi userspace device. <br>
  *
  * <br>
- * @section AutoInstall Automated Install 
+ * @section AutoInstall Automated Install
  *(**Designed & Tested on RPi** - Defaults to SPIDEV on devices supporting it)
  *
- * 
+ *
  * 1. Install prerequisites if there are any (MRAA, LittleWire libraries, setup SPI device etc)
  * 2. Download the install.sh file from http://tmrh20.github.io/RF24Installer/RPi/install.sh
  * @code wget http://tmrh20.github.io/RF24Installer/RPi/install.sh @endcode
@@ -1694,13 +1704,13 @@ private:
  * 4. Run it and choose your options
  * @code ./install.sh @endcode
  * 5. Run an example from one of the libraries
- * @code 
- * cd rf24libs/RF24/examples_linux  
+ * @code
+ * cd rf24libs/RF24/examples_linux
  * @endcode
  * Edit the gettingstarted example, to set your pin configuration
  * @code nano gettingstarted.cpp
- * make  
- * sudo ./gettingstarted  
+ * make
+ * sudo ./gettingstarted
  * @endcode
  *
  * <br>
@@ -1709,7 +1719,7 @@ private:
  * @note See the <a href="http://iotdk.intel.com/docs/master/mraa/index.html">MRAA </a> documentation for more info on installing MRAA <br>
  * 2. Make a directory to contain the RF24 and possibly RF24Network lib and enter it
  * @code
- *  mkdir ~/rf24libs 
+ *  mkdir ~/rf24libs
  *  cd ~/rf24libs
 *  @endcode
  * 3. Clone the RF24 repo
@@ -1720,11 +1730,11 @@ private:
  * 6. Build the library, and run an example file
  * @code make; sudo make install @endcode
  * @code
- * cd examples_linux  
+ * cd examples_linux
  * @endcode
  * Edit the gettingstarted example, to set your pin configuration
- * @code nano gettingstarted.cpp 
- * make 
+ * @code nano gettingstarted.cpp
+ * make
  * sudo ./gettingstarted
  * @endcode
  *
@@ -1738,9 +1748,9 @@ private:
  * @endcode
  * 3. See the gettingstarted example for an example of pin configuration
  * <br><br>
- *   
+ *
  * @page MRAA MRAA
- *  
+ *
  * MRAA is a Low Level Skeleton Library for Communication on GNU/Linux platforms <br>
  * See http://iotdk.intel.com/docs/master/mraa/index.html for more information
  *
@@ -1773,15 +1783,15 @@ private:
  *
  * <br><br><br>
  *
- * 
  *
  *
- * @page RPi Linux General/Raspberry Pi 
+ *
+ * @page RPi Linux General/Raspberry Pi
  *
  * RF24 supports a variety of Linux based devices via various drivers. Some boards like RPi can utilize multiple methods
  * to drive the GPIO and SPI functionality.
  *
- * 
+ *
  * @section PreConfig Potential PreConfiguration
  *
  * If SPI is not already enabled, load it on boot:
@@ -1790,7 +1800,7 @@ private:
  * B. Select **Advanced** and **enable the SPI kernel module** <br>
  * C. Update other software and libraries
  * @code sudo apt-get update @endcode
- * @code sudo apt-get upgrade @endcode 
+ * @code sudo apt-get upgrade @endcode
  * <br>
  *
  * @section Build Build Options
@@ -1807,11 +1817,11 @@ private:
  * Using pin 15/GPIO 22 for CE, pin 24/GPIO8 (CE0) for CSN
  *
  * Can use any available SPI BUS for CSN.<br>
- * In general, use @code RF24 radio(<ce_pin>, <a>*10+<b>); @endcode for proper constructor to 
- * address correct spi device at /dev/spidev\<a\>.\<b\> 
+ * In general, use @code RF24 radio(<ce_pin>, <a>*10+<b>); @endcode for proper constructor to
+ * address correct spi device at /dev/spidev\<a\>.\<b\>
  * <br>
  * Choose any GPIO output pin for radio CE pin.
- * 
+ *
  * **General:**
  * @code RF24 radio(22,0); @endcode
  *
@@ -1824,11 +1834,11 @@ private:
  * **SPI_DEV Constructor**
  *
  * @code RF24 radio(22,0); @endcode
- * 
+ *
  *
  * https://www.raspberrypi.org/documentation/usage/gpio/
  *
- * **Pins:**  
+ * **Pins:**
  *
  * | PIN | NRF24L01 |    RPI     | RPi -P1 Connector |
  * |-----|----------|------------|-------------------|
@@ -1840,29 +1850,29 @@ private:
  * |  6  |   MOSI   | rpi-mosi   |     (19)          |
  * |  7  |   MISO   | rpi-miso   |     (21)          |
  * |  8  |   IRQ    |    -       |       -           |
- *   
- *   
- *  
- *  
+ *
+ *
+ *
+ *
  * <br><br>
  ****************
- *   
+ *
  * Based on the arduino lib from J. Coliz <maniacbug@ymail.com>  <br>
- * the library was berryfied by Purinda Gunasekara <purinda@gmail.com> <br>  
+ * the library was berryfied by Purinda Gunasekara <purinda@gmail.com> <br>
  * then forked from github stanleyseow/RF24 to https://github.com/jscrane/RF24-rpi  <br>
  * Network lib also based on https://github.com/farconada/RF24Network
  *
- * 
  *
- * 
+ *
+ *
  * <br><br><br>
- * 
  *
- *  
+ *
+ *
  * @page Python Python Wrapper (by https://github.com/mz-fuzzy)
  *
  * @section Prerequisites Prerequisites
- * 
+ *
  * <b>Python2:</b>
  *
  * @code sudo apt-get install python-dev libboost-python-dev python-setuptools python-rpi.gpio @endcode
@@ -1887,19 +1897,19 @@ private:
  * 3. Install the library
  * @code sudo ./setup.py install  @endcode or @code sudo python3 setup.py install @endcode
  * See the additional <a href="pages.html">Platform Support</a> pages for information on connecting your hardware  <br>
- * See the included <a href="pingpair_dyn_8py-example.html">example </a> for usage information.   
- * 
+ * See the included <a href="pingpair_dyn_8py-example.html">example </a> for usage information.
+ *
  * 5. Running the Example: <br>
- * Edit the pingpair_dyn.py example to configure the appropriate pins per the above documentation:  
+ * Edit the pingpair_dyn.py example to configure the appropriate pins per the above documentation:
  * @code nano pingpair_dyn.py   @endcode
  * Configure another device, Arduino or RPi with the <a href="pingpair_dyn_8py-example.html">pingpair_dyn</a> example <br>
- * Run the example  
+ * Run the example
  * @code sudo ./pingpair_dyn.py  @endcode or @code sudo python3 pingpair_dyn.py @endcode
  *
  * <br><br><br>
  *
  * @page CrossCompile Linux cross-compilation
- * 
+ *
  * RF24 library supports cross-compilation. Advantages of cross-compilation:
  *  - development tools don't have to be installed on target machine
  *  - resources of target machine don't have to be sufficient for compilation
@@ -1972,16 +1982,16 @@ private:
  * <br><br><br>
  *
  * @page ATXMEGA ATXMEGA
- * 
+ *
  * The RF24 driver can be build as a static library with Atmel Studio 7 in order to be included as any other library in another program for the XMEGA family.
  *
  * Currently only the <b>ATXMEGA D3</b> family is implemented.
- * 
- * @section Preparation 
- * 
+ *
+ * @section Preparation
+ *
  * Create an empty GCC Static Library project in AS7.<br>
  * As not all files are required, copy the following directory structure in the project:
- * 
+ *
  * @code
  * utility\
  *   ATXMegaD3\
@@ -2001,38 +2011,38 @@ private:
  * RF24.h
  * RF24_config.h
  * @endcode
- * 
+ *
  * @section Usage
- * 
+ *
  * Add the library to your project!<br>
  * In the file where the **main()** is put the following in order to update the millisecond functionality:
- * 
+ *
  * @code
  * ISR(TCE0_OVF_vect)
  * {
  * 	update_milisec();
  * }
  * @endcode
- * 
+ *
  * Declare the rf24 radio with **RF24 radio(XMEGA_PORTC_PIN3, XMEGA_SPI_PORT_C);**
- * 
+ *
  * First parameter is the CE pin which can be any available pin on the uC.
- * 
- * Second parameter is the CS which can be on port C (**XMEGA_SPI_PORT_C**) or on port D (**XMEGA_SPI_PORT_D**). 
- * 
+ *
+ * Second parameter is the CS which can be on port C (**XMEGA_SPI_PORT_C**) or on port D (**XMEGA_SPI_PORT_D**).
+ *
  * Call the **__start_timer()** to start the millisecond timer.
- * 
+ *
  * @note Note about the millisecond functionality:<br>
- * 
+ *
  * 	The millisecond functionality is based on the TCE0 so don't use these pins as IO.<br>
- * 	The operating frequency of the uC is 32MHz. If you have other frequency change the TCE0 registers appropriatly in function **__start_timer()** in **compatibility.c** file for your frequency. 
+ * 	The operating frequency of the uC is 32MHz. If you have other frequency change the TCE0 registers appropriatly in function **__start_timer()** in **compatibility.c** file for your frequency.
  *
  * @page Portability RF24 Portability
  *
  * The RF24 radio driver mainly utilizes the <a href="http://arduino.cc/en/reference/homePage">Arduino API</a> for GPIO, SPI, and timing functions, which are easily replicated
- * on various platforms. <br>Support files for these platforms are stored under RF24/utility, and can be modified to provide 
+ * on various platforms. <br>Support files for these platforms are stored under RF24/utility, and can be modified to provide
  * the required functionality.
- * 
+ *
  * <br>
  * @section Hardware_Templates Basic Hardware Template
  *
@@ -2041,18 +2051,18 @@ private:
  * The RF24 library now includes a basic hardware template to assist in porting to various platforms. <br> The following files can be included
  * to replicate standard Arduino functions as needed, allowing devices from ATTiny to Raspberry Pi to utilize the same core RF24 driver.
  *
- * | File               |                   Purpose                                                    | 
- * |--------------------|------------------------------------------------------------------------------| 
- * | RF24_arch_config.h | Basic Arduino/AVR compatibility, includes for remaining support files, etc   | 
- * | includes.h         | Linux only. Defines specific platform, include correct RF24_arch_config file | 
- * | spi.h              | Provides standardized SPI ( transfer() ) methods                         | 
- * | gpio.h             | Provides standardized GPIO ( digitalWrite() ) methods                        | 
- * | compatibility.h    | Provides standardized timing (millis(), delay()) methods                     | 
- * | your_custom_file.h | Provides access to custom drivers for spi,gpio, etc                          | 
+ * | File               |                   Purpose                                                    |
+ * |--------------------|------------------------------------------------------------------------------|
+ * | RF24_arch_config.h | Basic Arduino/AVR compatibility, includes for remaining support files, etc   |
+ * | includes.h         | Linux only. Defines specific platform, include correct RF24_arch_config file |
+ * | spi.h              | Provides standardized SPI ( transfer() ) methods                         |
+ * | gpio.h             | Provides standardized GPIO ( digitalWrite() ) methods                        |
+ * | compatibility.h    | Provides standardized timing (millis(), delay()) methods                     |
+ * | your_custom_file.h | Provides access to custom drivers for spi,gpio, etc                          |
  *
  * <br>
  * Examples are provided via the included hardware support templates in **RF24/utility** <br>
- * See the <a href="modules.html">modules</a> page for examples of class declarations 
+ * See the <a href="modules.html">modules</a> page for examples of class declarations
  *
  *<br>
  * @section Device_Detection Device Detection
@@ -2064,7 +2074,7 @@ private:
  * <br>
  * @section Ported_Code Code
  * To have your ported code included in this library, or for assistance in porting, create a pull request or open an issue at https://github.com/TMRh20/RF24
- * 
+ *
  *
  *<br><br><br>
  */

--- a/examples/GettingStarted_CallResponse/GettingStarted_CallResponse.ino
+++ b/examples/GettingStarted_CallResponse/GettingStarted_CallResponse.ino
@@ -48,7 +48,6 @@ void setup(){
 
   radio.begin();
 
-  radio.enableDynamicPayloads();                // needed for using ACK payloads
   radio.enableAckPayload();                     // Allow optional ack payloads
   radio.enableDynamicPayloads();                // Ack payloads are dynamic payloads
 

--- a/examples/GettingStarted_CallResponse/GettingStarted_CallResponse.ino
+++ b/examples/GettingStarted_CallResponse/GettingStarted_CallResponse.ino
@@ -3,15 +3,15 @@
    Derived from examples by J. Coliz <maniacbug@ymail.com>
 */
 /**
- * Example for efficient call-response using ack-payloads 
- * 
- * This example continues to make use of all the normal functionality of the radios including 
- * the auto-ack and auto-retry features, but allows ack-payloads to be written optionlly as well. 
- * This allows very fast call-response communication, with the responding radio never having to 
- * switch out of Primary Receiver mode to send back a payload, but having the option to switch to 
- * primary transmitter if wanting to initiate communication instead of respond to a commmunication. 
+ * Example for efficient call-response using ack-payloads
+ *
+ * This example continues to make use of all the normal functionality of the radios including
+ * the auto-ack and auto-retry features, but allows ack-payloads to be written optionlly as well.
+ * This allows very fast call-response communication, with the responding radio never having to
+ * switch out of Primary Receiver mode to send back a payload, but having the option to switch to
+ * primary transmitter if wanting to initiate communication instead of respond to a commmunication.
  */
- 
+
 #include <SPI.h>
 #include "RF24.h"
 
@@ -29,7 +29,7 @@ RF24 radio(7,8);
 byte addresses[][6] = {"1Node","2Node"};              // Radio pipe addresses for the 2 nodes to communicate.
 
 // Role management: Set up role.  This sketch uses the same software for all the nodes
-// in this system.  Doing so greatly simplifies testing.  
+// in this system.  Doing so greatly simplifies testing.
 typedef enum { role_ping_out = 1, role_pong_back } role_e;                 // The various roles supported by this sketch
 const char* role_friendly_name[] = { "invalid", "Ping out", "Pong back"};  // The debug-friendly names of those roles
 role_e role = role_pong_back;                                              // The role of the current running sketch
@@ -43,14 +43,15 @@ void setup(){
   // printf_begin(); // This is for initializing printf that is used by printDetails()
   Serial.println(F("RF24/examples/GettingStarted_CallResponse"));
   Serial.println(F("*** PRESS 'T' to begin transmitting to the other node"));
- 
+
   // Setup and configure radio
 
   radio.begin();
 
+  radio.enableDynamicPayloads();                // needed for using ACK payloads
   radio.enableAckPayload();                     // Allow optional ack payloads
   radio.enableDynamicPayloads();                // Ack payloads are dynamic payloads
-  
+
   if(radioNumber){
     radio.openWritingPipe(addresses[1]);        // Both radios listen on the same pipes by default, but opposite addresses
     radio.openReadingPipe(1,addresses[0]);      // Open a reading pipe on address 0, pipe 1
@@ -58,37 +59,37 @@ void setup(){
     radio.openWritingPipe(addresses[0]);
     radio.openReadingPipe(1,addresses[1]);
   }
-  radio.startListening();                       // Start listening  
-  
+  radio.startListening();                       // Start listening
+
   radio.writeAckPayload(1,&counter,1);          // Pre-load an ack-paylod into the FIFO buffer for pipe 1
-  //radio.printDetails(); 
+  //radio.printDetails();
 }
 
 void loop(void) {
 
-  
+
 /****************** Ping Out Role ***************************/
 
   if (role == role_ping_out){                               // Radio is in ping mode
 
     byte gotByte;                                           // Initialize a variable for the incoming response
-    
-    radio.stopListening();                                  // First, stop listening so we can talk.      
+
+    radio.stopListening();                                  // First, stop listening so we can talk.
     Serial.print(F("Now sending "));                         // Use a simple byte counter as payload
     Serial.println(counter);
-    
-    unsigned long time = micros();                          // Record the current microsecond count   
-                                                            
-    if ( radio.write(&counter,1) ){                         // Send the counter variable to the other radio 
+
+    unsigned long time = micros();                          // Record the current microsecond count
+
+    if ( radio.write(&counter,1) ){                         // Send the counter variable to the other radio
         if(!radio.available()){                             // If nothing in the buffer, we got an ack but it is blank
             Serial.print(F("Got blank response. round-trip delay: "));
             Serial.print(micros()-time);
-            Serial.println(F(" microseconds"));     
-        }else{      
+            Serial.println(F(" microseconds"));
+        }else{
             while(radio.available() ){                      // If an ack with payload was received
                 radio.read( &gotByte, 1 );                  // Read it, and display the response time
                 unsigned long timer = micros();
-                
+
                 Serial.print(F("Got response "));
                 Serial.print(gotByte);
                 Serial.print(F(" round-trip delay: "));
@@ -97,9 +98,9 @@ void loop(void) {
                 counter++;                                  // Increment the counter variable
             }
         }
-    
+
     }else{        Serial.println(F("Sending failed.")); }          // If no ack response, sending failed
-    
+
     delay(1000);  // Try again later
   }
 
@@ -109,12 +110,12 @@ void loop(void) {
   if ( role == role_pong_back ) {
     byte pipeNo, gotByte;                          // Declare variables for the pipe and the byte received
     while( radio.available(&pipeNo)){              // Read all available payloads
-      radio.read( &gotByte, 1 );                   
+      radio.read( &gotByte, 1 );
                                                    // Since this is a call-response. Respond directly with an ack payload.
       gotByte += 1;                                // Ack payloads are much more efficient than switching to transmit mode to respond to a call
       radio.writeAckPayload(pipeNo,&gotByte, 1 );  // This can be commented out to send empty payloads.
       Serial.print(F("Loaded next response "));
-      Serial.println(gotByte);  
+      Serial.println(gotByte);
    }
  }
 
@@ -125,18 +126,18 @@ void loop(void) {
   if ( Serial.available() )
   {
     char c = toupper(Serial.read());
-    if ( c == 'T' && role == role_pong_back ){      
+    if ( c == 'T' && role == role_pong_back ){
       Serial.println(F("*** CHANGING TO TRANSMIT ROLE -- PRESS 'R' TO SWITCH BACK"));
       role = role_ping_out;  // Become the primary transmitter (ping out)
       counter = 1;
    }else
     if ( c == 'R' && role == role_ping_out ){
-      Serial.println(F("*** CHANGING TO RECEIVE ROLE -- PRESS 'T' TO SWITCH BACK"));      
+      Serial.println(F("*** CHANGING TO RECEIVE ROLE -- PRESS 'T' TO SWITCH BACK"));
        role = role_pong_back; // Become the primary receiver (pong back)
        radio.startListening();
        counter = 1;
        radio.writeAckPayload(1,&counter,1);
-       
+
     }
   }
 }

--- a/examples/pingpair_ack/pingpair_ack.ino
+++ b/examples/pingpair_ack/pingpair_ack.ino
@@ -44,8 +44,8 @@ void setup() {
 
   radio.begin();
   radio.setAutoAck(1);                    // Ensure autoACK is enabled
-  radio.enableDynamicPayloads();          // needed for using ACK payloads
   radio.enableAckPayload();               // Allow optional ack payloads
+  radio.enableDynamicPayloads();          // needed for using ACK payloads
   radio.setRetries(0, 15);                // Smallest time between retries, max no. of retries
   radio.setPayloadSize(1);                // Here we are sending 1-byte payloads to test the call-response speed
   radio.openWritingPipe(pipes[1]);        // Both radios listen on the same pipes by default, and switch when writing

--- a/examples/pingpair_ack/pingpair_ack.ino
+++ b/examples/pingpair_ack/pingpair_ack.ino
@@ -44,6 +44,7 @@ void setup() {
 
   radio.begin();
   radio.setAutoAck(1);                    // Ensure autoACK is enabled
+  radio.enableDynamicPayloads();          // needed for using ACK payloads
   radio.enableAckPayload();               // Allow optional ack payloads
   radio.setRetries(0, 15);                // Smallest time between retries, max no. of retries
   radio.setPayloadSize(1);                // Here we are sending 1-byte payloads to test the call-response speed

--- a/examples/pingpair_irq/pingpair_irq.ino
+++ b/examples/pingpair_irq/pingpair_irq.ino
@@ -4,7 +4,7 @@
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
  version 2 as published by the Free Software Foundation.
- 
+
  Update 2014 - TMRh20
  */
 
@@ -12,7 +12,7 @@
  * Example of using interrupts
  *
  * This is an example of how to user interrupts to interact with the radio, and a demonstration
- * of how to use them to sleep when receiving, and not miss any payloads. 
+ * of how to use them to sleep when receiving, and not miss any payloads.
  * The pingpair_sleepy example expands on sleep functionality with a timed sleep option for the transmitter.
  * Sleep functionality is built directly into my fork of the RF24Network library
  */
@@ -24,7 +24,7 @@
 
 // Hardware configuration
 RF24 radio(7,8);                          // Set up nRF24L01 radio on SPI bus plus pins 7 & 8
-                                        
+
 const short role_pin = 5;                 // sets the role of this unit in hardware.  Connect to GND to be the 'pong' receiver
                                           // Leave open to be the 'ping' transmitter
 
@@ -48,7 +48,7 @@ static uint32_t message_count = 0;
 
 void setup(){
 
-  pinMode(role_pin, INPUT);                        // set up the role pin                  
+  pinMode(role_pin, INPUT);                        // set up the role pin
   digitalWrite(role_pin,HIGH);                     // Change this to LOW/HIGH instead of using an external pin
   delay(20);                                       // Just to get a solid reading on the role pin
 
@@ -64,20 +64,21 @@ void setup(){
   Serial.println(role_friendly_name[role]);
 
   // Setup and configure rf radio
-  radio.begin();  
+  radio.begin();
   //radio.setPALevel(RF24_PA_LOW);
+  radio.enableDynamicPayloads();                    // needed for using ACK payloads
   radio.enableAckPayload();                         // We will be using the Ack Payload feature, so please enable it
   radio.enableDynamicPayloads();                    // Ack payloads are dynamic payloads
                                                     // Open pipes to other node for communication
-  if ( role == role_sender ) {                      // This simple sketch opens a pipe on a single address for these two nodes to 
+  if ( role == role_sender ) {                      // This simple sketch opens a pipe on a single address for these two nodes to
      radio.openWritingPipe(address[0]);             // communicate back and forth.  One listens on it, the other talks to it.
-     radio.openReadingPipe(1,address[1]); 
+     radio.openReadingPipe(1,address[1]);
   }else{
     radio.openWritingPipe(address[1]);
     radio.openReadingPipe(1,address[0]);
     radio.startListening();
     radio.writeAckPayload( 1, &message_count, sizeof(message_count) );  // Add an ack packet for the next time around.  This is a simple
-    ++message_count;        
+    ++message_count;
   }
   radio.printDetails();                             // Dump the configuration of the rf unit for debugging
   delay(50);
@@ -90,7 +91,7 @@ void setup(){
 void loop() {
 
 
-  if (role == role_sender)  {                        // Sender role.  Repeatedly send the current time 
+  if (role == role_sender)  {                        // Sender role.  Repeatedly send the current time
     unsigned long time = millis();                   // Take the time, and send it.
       Serial.print(F("Now sending "));
       Serial.println(time);
@@ -100,7 +101,7 @@ void loop() {
 
 
   if(role == role_receiver){                        // Receiver does nothing except in IRQ
-  }  
+  }
 }
 
 
@@ -108,29 +109,29 @@ void loop() {
 
 void check_radio(void)                                // Receiver role: Does nothing!  All the work is in IRQ
 {
-  
+
   bool tx,fail,rx;
   radio.whatHappened(tx,fail,rx);                     // What happened?
-  
+
   if ( tx ) {                                         // Have we successfully transmitted?
       if ( role == role_sender ){   Serial.println(F("Send:OK")); }
       if ( role == role_receiver ){ Serial.println(F("Ack Payload:Sent")); }
   }
-  
+
   if ( fail ) {                                       // Have we failed to transmit?
       if ( role == role_sender ){   Serial.println(F("Send:Failed"));  }
       if ( role == role_receiver ){ Serial.println(F("Ack Payload:Failed"));  }
   }
-  
+
   if ( rx || radio.available()){                      // Did we receive a message?
-    
+
     if ( role == role_sender ) {                      // If we're the sender, we've received an ack payload
         radio.read(&message_count,sizeof(message_count));
         Serial.print(F("Ack: "));
         Serial.println(message_count);
     }
 
-    
+
     if ( role == role_receiver ) {                    // If we're the receiver, we've received a time message
       static unsigned long got_time;                  // Get this payload and dump it
       radio.read( &got_time, sizeof(got_time) );

--- a/examples/pingpair_irq/pingpair_irq.ino
+++ b/examples/pingpair_irq/pingpair_irq.ino
@@ -66,7 +66,6 @@ void setup(){
   // Setup and configure rf radio
   radio.begin();
   //radio.setPALevel(RF24_PA_LOW);
-  radio.enableDynamicPayloads();                    // needed for using ACK payloads
   radio.enableAckPayload();                         // We will be using the Ack Payload feature, so please enable it
   radio.enableDynamicPayloads();                    // Ack payloads are dynamic payloads
                                                     // Open pipes to other node for communication

--- a/examples_linux/gettingstarted_call_response.cpp
+++ b/examples_linux/gettingstarted_call_response.cpp
@@ -59,6 +59,7 @@ int main(int argc, char** argv)
 
     cout << "RPi/RF24/examples/gettingstarted_call_response\n";
     radio.begin();
+    radio.enableDynamicPayloads();          // needed for using ACK payloads
     radio.enableAckPayload();               // Allow optional ack payloads
     radio.enableDynamicPayloads();
     radio.printDetails();                   // Dump the configuration of the rf unit for debugging

--- a/examples_linux/gettingstarted_call_response.cpp
+++ b/examples_linux/gettingstarted_call_response.cpp
@@ -59,9 +59,8 @@ int main(int argc, char** argv)
 
     cout << "RPi/RF24/examples/gettingstarted_call_response\n";
     radio.begin();
-    radio.enableDynamicPayloads();          // needed for using ACK payloads
     radio.enableAckPayload();               // Allow optional ack payloads
-    radio.enableDynamicPayloads();
+    radio.enableDynamicPayloads();          // needed for using ACK payloads
     radio.printDetails();                   // Dump the configuration of the rf unit for debugging
 
 

--- a/examples_linux/interrupts/gettingstarted_call_response_int.cpp
+++ b/examples_linux/interrupts/gettingstarted_call_response_int.cpp
@@ -66,6 +66,7 @@ int main(int argc, char** argv)
 
     cout << "RPi/RF24/examples/gettingstarted_call_response_int\n";
     radio.begin();
+    radio.enableDynamicPayloads();          // needed for using ACK payloads
     radio.enableAckPayload();               // Allow optional ack payloads
     radio.enableDynamicPayloads();
     radio.printDetails();                   // Dump the configuration of the rf unit for debugging

--- a/examples_linux/interrupts/gettingstarted_call_response_int.cpp
+++ b/examples_linux/interrupts/gettingstarted_call_response_int.cpp
@@ -66,9 +66,8 @@ int main(int argc, char** argv)
 
     cout << "RPi/RF24/examples/gettingstarted_call_response_int\n";
     radio.begin();
-    radio.enableDynamicPayloads();          // needed for using ACK payloads
     radio.enableAckPayload();               // Allow optional ack payloads
-    radio.enableDynamicPayloads();
+    radio.enableDynamicPayloads();          // needed for using ACK payloads
     radio.printDetails();                   // Dump the configuration of the rf unit for debugging
 
 

--- a/examples_linux/interrupts/gettingstarted_call_response_int2.cpp
+++ b/examples_linux/interrupts/gettingstarted_call_response_int2.cpp
@@ -91,6 +91,7 @@ int main(int argc, char** argv)
 
     cout << "RPi/RF24/examples/gettingstarted_call_response\n";
     radio.begin();
+    radio.enableDynamicPayloads();          // needed for using ACK payloads
     radio.enableAckPayload();               // Allow optional ack payloads
     radio.enableDynamicPayloads();
     radio.printDetails();                   // Dump the configuration of the rf unit for debugging

--- a/examples_linux/interrupts/gettingstarted_call_response_int2.cpp
+++ b/examples_linux/interrupts/gettingstarted_call_response_int2.cpp
@@ -91,9 +91,8 @@ int main(int argc, char** argv)
 
     cout << "RPi/RF24/examples/gettingstarted_call_response\n";
     radio.begin();
-    radio.enableDynamicPayloads();          // needed for using ACK payloads
     radio.enableAckPayload();               // Allow optional ack payloads
-    radio.enableDynamicPayloads();
+    radio.enableDynamicPayloads();          // needed for using ACK payloads
     radio.printDetails();                   // Dump the configuration of the rf unit for debugging
 
 

--- a/tests/native/pingpair_irq.pde
+++ b/tests/native/pingpair_irq.pde
@@ -96,6 +96,7 @@ void setup(void)
     radio.begin();
 
     // We will be using the Ack Payload feature, so please enable it
+    radio.enableDynamicPayloads();  // needed for using ACK payloads
     radio.enableAckPayload();
 
     //

--- a/tests/native/pingpair_irq.pde
+++ b/tests/native/pingpair_irq.pde
@@ -96,8 +96,8 @@ void setup(void)
     radio.begin();
 
     // We will be using the Ack Payload feature, so please enable it
-    radio.enableDynamicPayloads();  // needed for using ACK payloads
     radio.enableAckPayload();
+    radio.enableDynamicPayloads();  // needed for using ACK payloads
 
     //
     // Open pipes to other nodes for communication

--- a/tests/pingpair_test/pingpair_test.pde
+++ b/tests/pingpair_test/pingpair_test.pde
@@ -172,8 +172,8 @@ void setup(void)
     radio.begin();
 
     // We will be using the Ack Payload feature, so please enable it
-    radio.enableDynamicPayloads();  // needed for using ACK payloads
     radio.enableAckPayload();
+    radio.enableDynamicPayloads();  // needed for using ACK payloads
 
     // Config 2 is special radio config
     if (configuration == '2') {

--- a/tests/pingpair_test/pingpair_test.pde
+++ b/tests/pingpair_test/pingpair_test.pde
@@ -113,7 +113,7 @@ void one_failed(void)
 }
 
 //
-// Setup 
+// Setup
 //
 
 void setup(void)
@@ -172,6 +172,7 @@ void setup(void)
     radio.begin();
 
     // We will be using the Ack Payload feature, so please enable it
+    radio.enableDynamicPayloads();  // needed for using ACK payloads
     radio.enableAckPayload();
 
     // Config 2 is special radio config
@@ -265,7 +266,7 @@ char* prbuf_in = prbuf;
 char* prbuf_out = prbuf;
 
 //
-// Loop 
+// Loop
 //
 
 static uint32_t message_count = 0;


### PR DESCRIPTION
addresses #653 

Also, I added a remark to the docs about needing to have auto-ack feature enable (if it wasn't implicitly obvious enough)

Most of the examples listed in #653 already enabled dynamic payloads, so I just added a comment to make sure it was clear why that feature needs to be enabled for ACK payloads (if it wasn't there).

My settings in VSCode automatically trim trailing whitespaces (space`  ` characters after the last alphanumeric or punctual character in each line). So, all of the files in this PR no longer have trailing whitespace. Apparently there were a lot of trailing whitespaces (especially in RF24.h), though it still adheres to the NASA C-style guidelines and doesn't affect compilation or doxygen generation.